### PR TITLE
Fixing how timezone conversion operations get translated to a Snowflake Query

### DIFF
--- a/django_snowflake/operations.py
+++ b/django_snowflake/operations.py
@@ -8,7 +8,7 @@ class DatabaseOperations(BaseDatabaseOperations):
 
     def _convert_field_to_tz(self, field_name, tzname):
         if settings.USE_TZ:
-            field_name = "CONVERT_TIMEZONE('%s', 'UTC', %s)" % (tzname, field_name)
+            field_name = "CONVERT_TIMEZONE('UTC', '%s', %s)" % (tzname, field_name)
         return field_name
 
     def datetime_extract_sql(self, lookup_type, field_name, tzname):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = django-snowflake
-version = 1.0.1
+version = 1.0.2
 author = Manan
 author_email = thakkar1016@gmail.com
 description = A backend for Django and Snowflake

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 setup(
     name='django-snowflake',
 
-    version='1.0.1',
+    version='1.0.2',
 
     description='A backend for Django and Snowflake',
 


### PR DESCRIPTION
Our `_convert_field_to_tz` method was passing parameters into SQL based on the parameters expected in MySql's `CONVERT_TZ` function definition, and not the parameters expected by Snowflake's `CONVERT_TIMESTAMP` function definition. 

Essentially, we had the source and target timezone parameters in the wrong order. This PR is to fix that, such that it matches [this expectation from Snowflake](https://docs.snowflake.com/en/sql-reference/functions/convert_timezone.html):

```
CONVERT_TIMEZONE( <source_tz> , <target_tz> , <source_timestamp_ntz> )
```
